### PR TITLE
Load Charm Store API info in background

### DIFF
--- a/bundleplacer/async.py
+++ b/bundleplacer/async.py
@@ -1,0 +1,68 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Async Handler
+Provides async operations for various api calls and other non-blocking
+work.
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+import time
+
+log = logging.getLogger("bundleplacer.async")
+
+
+class ThreadCancelledException(Exception):
+    """Exception meaning intentional cancellation"""
+
+AsyncPool = ThreadPoolExecutor(1)
+log.debug('AsyncPool={}'.format(AsyncPool))
+
+
+ShutdownEvent = Event()
+
+
+def submit(func, exc_callback):
+    def cb(cb_f):
+        e = cb_f.exception()
+        if e:
+            exc_callback(e)
+    if ShutdownEvent.is_set():
+        log.debug("ignoring async.submit due to impending shutdown.")
+        return
+    f = AsyncPool.submit(func)
+    f.add_done_callback(cb)
+    return f
+
+
+def shutdown():
+    ShutdownEvent.set()
+    AsyncPool.shutdown(wait=False)
+
+
+def sleep_until(s):
+    """returns after 's' seconds.
+
+    If the ShutdownEvent is raised before the wait is over,
+    raises a ThreadCancelledException.
+
+    """
+    start = time.time()
+    while not ShutdownEvent.wait(timeout=.1):
+        if time.time() - start >= s:
+            return True
+    raise ThreadCancelledException("Thread cancelled while sleeping")

--- a/bundleplacer/charm.py
+++ b/bundleplacer/charm.py
@@ -15,14 +15,14 @@
 
 
 class Charm:
-    def __init__(self, charm_name, charm_source, display_name,
-                 summary, constraints, depends, conflicts,
+    def __init__(self, charm_name, charm_source, summary_future,
+                 constraints, depends, conflicts,
                  allowed_assignment_types, num_units, options,
                  allow_multi_units, subordinate, required, relations):
         self.charm_name = charm_name
         self.charm_source = charm_source
-        self.display_name = display_name
-        self.summary = summary
+        self.summary_future = summary_future
+        self._summary = "Loading summary…"
         self.constraints = constraints
         self.depends = depends
         self.conflicts = conflicts
@@ -34,6 +34,17 @@ class Charm:
         self.is_core = required
         self.isolate = True if not subordinate else False
         self.relations = relations
+
+    @property
+    def summary(self):
+        if self.summary_future.done():
+            self._summary = self.summary_future.result()
+        return self._summary
+
+    @property
+    def display_name(self):
+        return "{} ({})".format(self.charm_name,
+                                self.charm_source)
 
     def required_num_units(self):
         return self.num_units

--- a/bundleplacer/cli.py
+++ b/bundleplacer/cli.py
@@ -19,6 +19,7 @@ import os
 import sys
 import urwid
 
+from bundleplacer import async
 from bundleplacer.maas import connect_to_maas
 
 from bundleplacer.config import Config
@@ -78,6 +79,7 @@ def main():
             path, ext = os.path.splitext(opts.bundle_filename)
             outfn = "{}-out{}".format(path, ext)
         bw.write_bundle(outfn)
+        async.shutdown()
         raise urwid.ExitMainLoop()
 
     mainview = PlacerView(placement_controller, config, cb)
@@ -85,6 +87,7 @@ def main():
 
     def unhandled_input(key):
         if key in ['q', 'Q']:
+            async.shutdown()
             raise urwid.ExitMainLoop()
     EventLoop.build_loop(ui, STYLES, unhandled_input=unhandled_input)
     mainview.loop = EventLoop.loop

--- a/bundleplacer/ui/service_widget.py
+++ b/bundleplacer/ui/service_widget.py
@@ -62,12 +62,15 @@ class ServiceWidget(WidgetWrap):
     def selectable(self):
         return True
 
-    def build_widgets(self):
+    def update_title_markup(self):
         dn = self.charm_class.display_name
         self.title_markup = ["\N{GEAR} {}".format(dn), ""]
-        if self.charm_class.summary != "":
-            self.title_markup.append("\n {}\n".format(self.charm_class.summary))
+        summary = self.charm_class.summary
+        if summary != "":
+            self.title_markup.append("\n {}\n".format(summary))
 
+    def build_widgets(self):
+        self.update_title_markup()
         self.charm_info_widget = Text(self.title_markup)
         self.placements_widget = Text("")
 
@@ -99,6 +102,8 @@ class ServiceWidget(WidgetWrap):
     def update(self):
         mstr = [""]
 
+        self.update_title_markup()
+
         state, cons, deps = self.controller.get_charm_state(self.charm_class)
 
         if state == CharmState.REQUIRED:
@@ -117,16 +122,12 @@ class ServiceWidget(WidgetWrap):
                 info_str += " - required by {}".format(dep_str)
 
             self.title_markup[1] = ('info', info_str)
-            self.charm_info_widget.set_text(self.title_markup)
-
         elif state == CharmState.CONFLICTED:
             con_str = ", ".join([c.display_name for c in cons])
             self.title_markup[1] = ('error_icon',
                                     ' - Conflicts with {}'.format(con_str))
-            self.charm_info_widget.set_text(self.title_markup)
         elif state == CharmState.OPTIONAL:
             self.title_markup[1] = ""
-            self.charm_info_widget.set_text(self.title_markup)
 
         def string_for_placement_dict(d):
             s = []
@@ -148,6 +149,7 @@ class ServiceWidget(WidgetWrap):
         mstr += ["\n    ", ('label', "Deployments: ")]
         mstr += string_for_placement_dict(dd)
 
+        self.charm_info_widget.set_text(self.title_markup)
         self.placements_widget.set_text(mstr)
 
         self.update_buttons()


### PR DESCRIPTION
Waiting for the charm store API and MAAS before showing UI makes the thing feel slow.
Instead, let's show UI and load in the background. This is step one, the charm store API.
1. Uses concurrent.futures to asynchronously load info from charm store.
2. Caches that info so we only hit the API once per charm
3. Reorganizes service widget to rebuild summary every update
4. Adds code to shutdown thread pool at exit

Signed-off-by: Michael McCracken mike.mccracken@canonical.com
