### PR TITLE
Load MAAS machines in background

### DIFF
--- a/bundleplacer/ui/__init__.py
+++ b/bundleplacer/ui/__init__.py
@@ -285,8 +285,8 @@ class MachinesColumn(WidgetWrap):
                                                 align='center',
                                                 width=BUTTON_SIZE)])
 
-        # 1 machine is the subordinate placeholder:
-        if len(self.placement_controller.machines()) == 1:
+        # 2 machines is the subordinate placeholder + juju default:
+        if len(self.placement_controller.machines()) == 2:
             self.main_pile.contents[2] = (self.empty_maas_widgets,
                                           self.main_pile.options())
         else:


### PR DESCRIPTION
Displays UI immediately then loads MAAS machines in background.

Retains previous behavior of caching and reloading every 20 seconds.

Signed-off-by: Michael McCracken mike.mccracken@canonical.com
