### PR TITLE
Charmstore search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ GIT_REV		    := $(shell git log --oneline -n1| cut -d" " -f1)
 VERSION             := $(shell ./tools/version)
 UPSTREAM_MAASCLIENT := https://github.com/Ubuntu-Solutions-Engineering/maasclient.git
 UPSTREAM_MAASCLIENT_COMMIT := 357db23
+UPSTREAM_UBUNTUI := https://github.com/Ubuntu-Solutions-Engineering/urwid-ubuntu
+UPSTREAM_UBUNTUI_COMMIT := master
+
 
 .PHONY: install-dependencies
 install-dependencies:
@@ -39,9 +42,13 @@ git-sync-requirements:
 	@echo Syncing git repos
 	rm -rf tmp && mkdir -p tmp
 	rm -rf maasclient
+	rm -rf ubuntui
 	git clone -q $(UPSTREAM_MAASCLIENT) tmp/maasclient
 	(cd tmp/maasclient && git checkout -q -f $(UPSTREAM_MAASCLIENT_COMMIT))
 	rsync -az --delete tmp/maasclient/maasclient .
+	git clone -q $(UPSTREAM_UBUNTUI) tmp/ubuntui
+	(cd tmp/ubuntui && git checkout -q -f $(UPSTREAM_UBUNTUI_COMMIT))
+	rsync -az --delete tmp/ubuntui/ubuntui .
 	rm -rf tmp
 
 git_rev:

--- a/bundleplacer/bundle.py
+++ b/bundleplacer/bundle.py
@@ -126,7 +126,8 @@ def create_service(servicename, service_dict, servicemeta, relations):
                           list(AssignmentType)),
                       num_units=service_dict.get('num_units', 1),
                       options=service_dict.get('options', {}),
-                      allow_multi_units=servicemeta.get('allow_multi_units', True),
+                      allow_multi_units=servicemeta.get('allow_multi_units',
+                                                        True),
                       subordinate=is_subordinate,
                       required=servicemeta.get('required', True),
                       relations=myrelations)
@@ -180,7 +181,7 @@ class Bundle:
         return ([a, b] in rels or [b, a] in rels or
                 [s1_name, s2_name] in rels or
                 [s2_name, s1_name] in rels)
-    
+
     @property
     def services(self):
         services = []
@@ -196,4 +197,3 @@ class Bundle:
     def extra_items(self):
         return {k: v for k, v in self._bundle.items()
                 if k not in ['services', 'machines', 'relations']}
-

--- a/bundleplacer/bundle.py
+++ b/bundleplacer/bundle.py
@@ -23,6 +23,7 @@ from bundleplacer.async import submit
 from bundleplacer.service import Service
 from bundleplacer.assignmenttype import AssignmentType, label_to_atype
 
+
 log = logging.getLogger('bundleplacer')
 
 
@@ -94,6 +95,16 @@ class CharmStoreAPI:
 
     def get_entity(self, charm_name, exc_cb):
         return self._lookup(charm_name, None, exc_cb)
+
+    def get_matches(self, substring, exc_cb):
+        def _do_search():
+            url = (self.baseurl + "/search?text={}".format(substring) +
+                   "&autocomplete=1&limit=10&include=charm-metadata")
+            r = requests.get(url)
+            rj = r.json()
+            return rj
+        f = submit(_do_search, exc_cb)
+        return f
 
 
 def create_service(servicename, service_dict, servicemeta, relations):

--- a/bundleplacer/placerview.py
+++ b/bundleplacer/placerview.py
@@ -72,6 +72,9 @@ class PlacerView(WidgetWrap):
     def set_selected_service(self, service):
         self.selected_service = service
 
+    def show_default_view(self):
+        self.pv.show_default_view()
+
     def edit_placement(self):
         self.pv.edit_placement()
 

--- a/bundleplacer/ui/__init__.py
+++ b/bundleplacer/ui/__init__.py
@@ -141,16 +141,22 @@ class PlacementView(WidgetWrap):
         self.services_button_grid = GridFlow(self.services_buttons,
                                              36, 1, 0, 'center')
 
-        self.services_header_pile = Pile([Text(("body", "Services"),
+        self.services_header_pile = Pile([Text(("bobdy", "Services"),
                                                align='center'),
                                           Divider(),
                                           self.services_button_grid])
 
         return self.services_header_pile
 
-    def get_charmstore_header(self):
-        self.charm_search_widget = CharmStoreSearchWidget(self.do_add_charm)
-        return self.charm_search_widget
+    def get_charmstore_header(self, charmstore_column):
+        self.charm_search_widget = CharmStoreSearchWidget(self.do_add_charm,
+                                                          charmstore_column)
+        self.charm_search_header_pile = Pile([Text(("bobdy", "Add Charms"),
+                                                   align='center'),
+                                              Divider(),
+                                              self.charm_search_widget])
+
+        return self.charm_search_header_pile
 
     def get_machines_header(self, machines_column):
 
@@ -289,16 +295,14 @@ class PlacementView(WidgetWrap):
         """Add new service and focus its widget.
 
         """
+        assert(self.state == UIState.CHARMSTORE_VIEW)
         service_name = self.placement_controller.add_new_service(charm_name,
                                                                  charm_dict)
         self.frame.focus_position = 'body'
         self.columns.focus_position = 0
+        self.relations_column.add_charm(charm_name)
         self.update()
-        if self.state == UIState.RELATION_EDITOR:
-            self.relations_column.add_charm(charm_name)
-            self.relations_column.refresh()
-        else:
-            self.services_column.select_service(service_name)
+        self.services_column.select_service(service_name)
 
     def do_clear_machine(self, sender, machine):
         self.placement_controller.clear_assignments(machine)
@@ -309,6 +313,7 @@ class PlacementView(WidgetWrap):
 
     def reset_selections(self, top=False):
         self.clear_selections()
+        self.state = UIState.CHARMSTORE_VIEW
         self.update()
         self.columns.focus_position = 0
 
@@ -327,12 +332,16 @@ class PlacementView(WidgetWrap):
 
     def focus_charmstore_column(self):
         self.columns.focus_position = 1
-        self.charmstore_column.focus()
+        self.charmstore_column.focus_prev_or_top()
 
     def edit_placement(self):
         self.state = UIState.PLACEMENT_EDITOR
         self.update()
         self.focus_machines_column()
+
+    def show_default_view(self):
+        self.state = UIState.CHARMSTORE_VIEW
+        self.update()
 
     def edit_relations(self, service):
         self.state = UIState.RELATION_EDITOR

--- a/bundleplacer/ui/__init__.py
+++ b/bundleplacer/ui/__init__.py
@@ -23,7 +23,7 @@ from urwid import (AttrMap, Button, Columns, Divider, Filler, Overlay,
 from ubuntui.views import InfoDialogWidget
 from ubuntui.widgets import MetaScroll
 
-from bundleplacer.ui.charmstore_search_widget import CharmStoreSearchWidget
+from bundleplacer.ui.charmstore import CharmstoreColumn, CharmStoreSearchWidget
 from bundleplacer.ui.filter_box import FilterBox
 from bundleplacer.ui.services_column import ServicesColumn
 from bundleplacer.ui.machines_column import MachinesColumn
@@ -38,7 +38,7 @@ BUTTON_SIZE = 20
 class UIState(Enum):
     PLACEMENT_EDITOR = 0
     RELATION_EDITOR = 1
-
+    CHARMSTORE_VIEW = 2         # This is the default
 
 class PlacementView(WidgetWrap):
 
@@ -52,7 +52,7 @@ class PlacementView(WidgetWrap):
     """
 
     def __init__(self, display_controller, placement_controller,
-                 config, do_deploy_cb, initial_state=UIState.PLACEMENT_EDITOR):
+                 config, do_deploy_cb, initial_state=UIState.CHARMSTORE_VIEW):
         self.display_controller = display_controller
         self.placement_controller = placement_controller
         self.config = config
@@ -74,10 +74,11 @@ class PlacementView(WidgetWrap):
         self.frame.footer.focus_position = 1
 
     def handle_tab(self, backward):
-        if self.state == UIState.PLACEMENT_EDITOR:
-            tabloop = ['headercol1', 'col1', 'headercol2', 'col2', 'footer']
-        else:
+        if self.state == UIState.RELATION_EDITOR:
+            # Relation editor has no header col.
             tabloop = ['headercol1', 'col1', 'col2', 'footer']
+        else:
+            tabloop = ['headercol1', 'col1', 'headercol2', 'col2', 'footer']
 
         def goto_header_col1():
             self.frame.focus_position = 'header'
@@ -95,8 +96,10 @@ class PlacementView(WidgetWrap):
             self.frame.focus_position = 'body'
             if self.state == UIState.PLACEMENT_EDITOR:
                 self.focus_machines_column()
-            else:
+            elif self.state == UIState.RELATION_EDITOR:
                 self.focus_relations_column()
+            else:
+                self.focus_charmstore_column()
 
         actions = {'headercol1': goto_header_col1,
                    'headercol2': goto_header_col2,
@@ -134,8 +137,6 @@ class PlacementView(WidgetWrap):
                                         'button_secondary',
                                         'button_secondary focus')
 
-        self.charm_search_widget = CharmStoreSearchWidget(self.do_add_charm)
-
         self.services_buttons = [self.clear_all_button]
         self.services_button_grid = GridFlow(self.services_buttons,
                                              36, 1, 0, 'center')
@@ -143,10 +144,13 @@ class PlacementView(WidgetWrap):
         self.services_header_pile = Pile([Text(("body", "Services"),
                                                align='center'),
                                           Divider(),
-                                          self.services_button_grid,
-                                          Divider(),
-                                          self.charm_search_widget])
+                                          self.services_button_grid])
+
         return self.services_header_pile
+
+    def get_charmstore_header(self):
+        self.charm_search_widget = CharmStoreSearchWidget(self.do_add_charm)
+        return self.charm_search_widget
 
     def get_machines_header(self, machines_column):
 
@@ -189,12 +193,17 @@ class PlacementView(WidgetWrap):
         self.relations_column = RelationsColumn(self.display_controller,
                                                 self.placement_controller,
                                                 self)
+        self.charmstore_column = CharmstoreColumn(self.display_controller,
+                                                  self.placement_controller,
+                                                  self)
 
         self.machines_header = self.get_machines_header(self.machines_column)
         self.relations_header = self.get_relations_header()
+        self.services_header = self.get_services_header()
+        self.charmstore_header = self.get_charmstore_header(
+            self.charmstore_column)
 
-        cs = [self.get_services_header(),
-              self.machines_header]
+        cs = [self.services_header, self.charmstore_header]
 
         self.header_columns = Columns(cs, dividechars=2)
 
@@ -231,6 +240,11 @@ class PlacementView(WidgetWrap):
                 self.header_columns.contents[-1] = (self.relations_header,
                                                     h_opts)
                 self.columns.contents[-1] = (self.relations_column, h_opts)
+            elif self.state == UIState.CHARMSTORE_VIEW:
+                self.header_columns.contents[-1] = (self.charmstore_header,
+                                                    h_opts)
+                self.columns.contents[-1] = (self.charmstore_column, h_opts)
+
             self.prev_state = self.state
 
         self.services_column.update()
@@ -310,6 +324,10 @@ class PlacementView(WidgetWrap):
     def focus_relations_column(self):
         self.columns.focus_position = 1
         self.relations_column.focus_prev_or_top()
+
+    def focus_charmstore_column(self):
+        self.columns.focus_position = 1
+        self.charmstore_column.focus()
 
     def edit_placement(self):
         self.state = UIState.PLACEMENT_EDITOR

--- a/bundleplacer/ui/charmstore.py
+++ b/bundleplacer/ui/charmstore.py
@@ -100,3 +100,39 @@ class CharmStoreSearchWidget(WidgetWrap):
 
     def do_add_charm(self, sender):
         self.add_cb(self.search_text, self._search_result)
+
+
+class CharmstoreColumn(WidgetWrap):
+    def __init__(self, display_controller, placement_controller,
+                 placement_view):
+        self.placement_controller = placement_controller
+        self.display_controller = display_controller
+        self.placement_view = placement_view
+        w = self.build_widgets()
+        super().__init__(w)
+        self.update()
+
+    def build_widgets(self):
+        self.title = Text('')
+        self.relation_widgets = []
+
+        self.pile = Pile([Divider(), self.title] + self.relation_widgets)
+        return self.pile
+
+    def refresh(self):
+        self.set_service(self.service)
+
+    def set_service(self, service):
+        self.service = service
+        self.add_charm(service.charm_name)
+        self.pile.contents = self.pile.contents[:2]
+        self.provides = set()
+        self.requires = set()
+        self.relation_widgets = []
+
+    def update(self):
+        if self.service is None:
+            return
+
+        self.title.set):
+        w = self.build_widgets()

--- a/bundleplacer/ui/charmstore.py
+++ b/bundleplacer/ui/charmstore.py
@@ -13,22 +13,29 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from enum import Enum
 import logging
 
-from urwid import (AttrMap, Button, Columns, connect_signal, Edit,
-                   Padding, Pile, SelectableIcon, Text, WidgetWrap)
+
+from urwid import (AttrMap, Button, Columns, Divider, connect_signal,
+                   ListBox, Filler, BoxAdapter, Edit, Filler, Padding,
+                   Pile, SimpleFocusListWalker, Text, WidgetWrap)
+
+from ubuntui.ev import EventLoop
+from ubuntui.widgets.buttons import MenuSelectButton
 
 from bundleplacer.bundle import CharmStoreAPI
-
 
 log = logging.getLogger('bundleplacer')
 
 
 class CharmStoreSearchWidget(WidgetWrap):
 
-    def __init__(self, add_cb):
+    def __init__(self, add_cb, charmstore_column=None):
         self.add_cb = add_cb
+        self.charmstore_column = charmstore_column
         self.api = CharmStoreAPI()
+        self.search_delay_alarm = None
         self.search_text = ""
         self._search_future = None
         self._search_result = None
@@ -36,70 +43,105 @@ class CharmStoreSearchWidget(WidgetWrap):
         super().__init__(w)
 
     def build_widgets(self):
-        self.info_text = Text("")
         self.editbox = Edit(caption=('text', "Search Charm Store: "))
 
         connect_signal(self.editbox, 'change',
                        self.handle_edit_changed)
 
-        self.do_search_button = AttrMap(Button("Search",
-                                               on_press=self.do_search),
-                                        'button_secondary',
-                                        'button_secondary focus')
-        self.add_charm_dummy = AttrMap(SelectableIcon("(Add new charm)"),
-                                       'disabled_button',
-                                       'disabled_button_focus')
-        self.add_charm_button = AttrMap(Button("Add",
-                                               on_press=self.do_add_charm),
-                                        'button_secondary',
-                                        'button_secondary focus')
-        self.top = Columns([AttrMap(self.editbox,
-                                    'filter', 'filter_focus'),
-                            (22, self.do_search_button)], dividechars=2)
-        self.bottom = Columns([self.info_text,
-                               (22, self.add_charm_dummy)], dividechars=2)
-
-        return Padding(Pile([self.top, self.bottom]), left=6)
+        return Padding(AttrMap(self.editbox,
+                               'filter', 'filter_focus'), left=2, right=2)
 
     def update(self):
         if self._search_future and self._search_future.done():
             self._search_result = self._search_future.result()
             self._search_future = None
-
+            
             # result being None indicates an error, which was handled by
             # handle_search_error.
-            if self._search_result is not None:
-                meta = self._search_result['Meta']['charm-metadata']
-                summary = meta['Summary']
-                self.info_text.set_text(summary)
-                _, opts = self.bottom.contents[-1]
-                self.bottom.contents[-1] = (self.add_charm_button,
-                                            opts)
-            return
+            if self._search_result is None:
+                return
+            if self.charmstore_column is None:
+                return
 
-        if self._search_future is None and self._search_result is None:
-            _, opts = self.bottom.contents[-1]
-            self.bottom.contents[-1] = (self.add_charm_dummy,
-                                        opts)
+            self.charmstore_column.clear_search_results()
+            results = self._search_result['Results']
+            for r in results:
+                match_name = r['Id']
+                self.charmstore_column.add_result(match_name, r)
+            self.charmstore_column.update()
+
+            return
 
     def handle_edit_changed(self, sender, userdata):
         self.search_text = userdata
+        if self.charmstore_column:
+            
+            self.enqueue_search(None)
+            self.charmstore_column.handle_search_change(userdata)
 
-    def do_search(self, sender):
-        self._search_future = None
+    def enqueue_search(self, sender):
+        if self.search_delay_alarm:
+            EventLoop.remove_alarm(self.search_delay_alarm)
 
         if self.search_text == "":
             return
 
-        self._search_future = self.api.get_entity(self.search_text,
-                                                  self.handle_search_error)
-        self.info_text.set_text("Searching…")
+        self.search_delay_alarm = EventLoop.set_alarm_in(0.5,
+                                                         self.really_search)
+
+    def really_search(self, *args, **kwargs):
+        if self.charmstore_column:
+            msg = "Searching for {}".format(self.search_text)
+            self.charmstore_column.set_msg(msg)
+        self.search_delay_alarm = None
+        self._search_future = self.api.get_matches(self.search_text,
+                                                   self.handle_search_error)
+
+        def update_immediately(future):
+            self.update()
+            msg = "Charms matching {}:".format(self.search_text)
+            self.charmstore_column.set_msg(msg)
+            self.charmstore_column.update()
+
+        self._search_future.add_done_callback(update_immediately)
 
     def handle_search_error(self, e):
-        self.info_text.set_text("{} not found.".format(self.search_text))
+        if self.charmstore_column:
+            msg = "Error searching for {}: {}".format(self.search_text, e)
+            self.charmstore_column.set_msg(msg)
 
     def do_add_charm(self, sender):
         self.add_cb(self.search_text, self._search_result)
+
+
+class CharmWidget(WidgetWrap):
+    def __init__(self, charm_source, charm_dict, add_cb):
+        self.add_cb = add_cb
+        self.charm_source = charm_source
+        self.charm_dict = charm_dict
+        self.md = charm_dict['Meta']['charm-metadata']
+        w = self.build_widgets()
+        super().__init__(w)
+
+    def selectable(self):
+        return True
+        
+    def build_widgets(self):
+        self.charm_name = self.md['Name']
+        source = self.charm_source
+        summary = self.md['Summary']
+        s = "{} ({})\n  {}".format(self.charm_name, source, summary)
+        return AttrMap(MenuSelectButton(s, on_press=self.handle_press),
+                       'text',
+                       'button_secondary focus')
+
+    def handle_press(self, button):
+        self.add_cb(self.charm_name, self.charm_dict)
+
+
+class CharmstoreColumnUIState(Enum):
+    RELATED = 0
+    SEARCH_RESULTS = 1
 
 
 class CharmstoreColumn(WidgetWrap):
@@ -108,31 +150,55 @@ class CharmstoreColumn(WidgetWrap):
         self.placement_controller = placement_controller
         self.display_controller = display_controller
         self.placement_view = placement_view
+        self.state = CharmstoreColumnUIState.RELATED
+        self.prev_state = None
+        self.current_search_string = ""
         w = self.build_widgets()
         super().__init__(w)
+        self._related_charms = []
+        self._search_results = []
+        self.refresh_related()
         self.update()
 
     def build_widgets(self):
         self.title = Text('')
-        self.relation_widgets = []
-
-        self.pile = Pile([Divider(), self.title] + self.relation_widgets)
+        self.pile = Pile([Divider(),
+                          self.title])
         return self.pile
 
-    def refresh(self):
-        self.set_service(self.service)
+    def refresh_related(self):
+        pass
 
-    def set_service(self, service):
-        self.service = service
-        self.add_charm(service.charm_name)
-        self.pile.contents = self.pile.contents[:2]
-        self.provides = set()
-        self.requires = set()
-        self.relation_widgets = []
+    def clear_search_results(self):
+        self._search_results = []
+
+    def handle_search_change(self, s):
+        if s == "":
+            self.state = CharmstoreColumnUIState.RELATED
+            self.clear_search_results()
+        else:
+            self.state = CharmstoreColumnUIState.SEARCH_RESULTS
+        self.current_search_string = s
+        self.update()
 
     def update(self):
-        if self.service is None:
-            return
+        if self.state == CharmstoreColumnUIState.RELATED:
+            self.title.set_text("Charms Related to this Bundle")
+            self.pile.contents = self.pile.contents[:2]
+        else:
+            opts = self.pile.options()
+            self.pile.contents[2:] = [(CharmWidget(n, d, self.do_add_charm),
+                                       opts) for n, d in self._search_results]
 
-        self.title.set):
-        w = self.build_widgets()
+    def add_result(self, charm_name, charm_dict):
+        self._search_results.append((charm_name, charm_dict))
+
+    def focus_prev_or_top(self):
+        self.pile.focus_position = 2
+
+    def do_add_charm(self, charm_name, charm_dict):
+        self.placement_view.do_add_charm(charm_name,
+                                         charm_dict)
+
+    def set_msg(self, msg):
+        self.title.set_text(msg)

--- a/bundleplacer/ui/simple_service_widget.py
+++ b/bundleplacer/ui/simple_service_widget.py
@@ -176,6 +176,7 @@ class SimpleServiceWidget(WidgetWrap):
     def do_cancel(self, sender):
         self.state = ServiceWidgetState.UNSELECTED
         self.update()
+        self.display_controller.show_default_view()
         self.pile.focus_position = 0
 
     def handle_placement_button_pressed(self, sender):


### PR DESCRIPTION
moves new-charm searching over to occupy the entire right hand side panel by default.

shows as-you-type search results, which you then choose from to add.
no search button and no add button.

you should be able to edit placements and relations and then get back to the search screen by de-selecting a widget (using 'cancel')
