### PR TITLE
limit search results and metadata to bundle's series

### DIFF
--- a/bundleplacer/bundle.py
+++ b/bundleplacer/bundle.py
@@ -173,6 +173,10 @@ class Bundle:
     def machines(self):
         return self._bundle.get('machines', {})
 
+    @property
+    def series(self):
+        return self._bundle.get('series', 'trusty')
+
     def clear_machines_and_placement(self):
         self._bundle['machines'] = {}
         for sname, sd in self._bundle['services'].items():

--- a/bundleplacer/ui/__init__.py
+++ b/bundleplacer/ui/__init__.py
@@ -161,9 +161,11 @@ class PlacementView(WidgetWrap):
         return Pile(ws)
 
     def get_charmstore_header(self, charmstore_column):
+        series = self.placement_controller.bundle.series
         self.charm_search_widget = CharmStoreSearchWidget(self.do_add_charm,
                                                           charmstore_column,
-                                                          self.config)
+                                                          self.config,
+                                                          series)
         self.charm_search_header_pile = Pile([Divider(),
                                               Text(("body", "Add Charms"),
                                                    align='center'),

--- a/bundleplacer/ui/charmstore.py
+++ b/bundleplacer/ui/charmstore.py
@@ -30,11 +30,11 @@ log = logging.getLogger('bundleplacer')
 
 class CharmStoreSearchWidget(WidgetWrap):
 
-    def __init__(self, add_cb, charmstore_column, config):
+    def __init__(self, add_cb, charmstore_column, config, series):
         self.add_cb = add_cb
         self.charmstore_column = charmstore_column
         self.config = config
-        self.api = CharmStoreAPI()
+        self.api = CharmStoreAPI(series=series)
         self.search_delay_alarm = None
         self.search_text = ""
         self._search_future = None


### PR DESCRIPTION
include bundle's series in api calls to get matching charms for search,
and charm metadata for charms in the bundle already.

Signed-off-by: Michael McCracken mike.mccracken@canonical.com
