### PR TITLE
Dont pass ConfigYAML if charm options are none

### DIFF
--- a/bundleplacer/service.py
+++ b/bundleplacer/service.py
@@ -75,8 +75,9 @@ class Service:
         rd = {"CharmUrl": self.charm_source,
               "ServiceName": self.service_name,
               "NumUnits": self.num_units,
-              "Constraints": self.constraints,
-              "ConfigYAML": optsyaml}
+              "Constraints": self.constraints}
+        if optsyaml:
+            rd["ConfigYAML"] = optsyaml
         if self.placement_spec:
             specs = [self._prepare_placement(self.placement_spec)]
             rd["Placement"] = yaml.dump(specs, default_flow_style=False)


### PR DESCRIPTION
Juju API doesn't like an empty yaml string in ConfigYAML. Don't pass this parameter at all if no charm options exist

Example api call with options for reference:

```
In [18]: juju.CLIENT.Service(request='Deploy', params={'Services': [{'CharmUrl': 'cs:trusty/mysql-38', 'ConfigYAML': 'mysql:\n  dataset-size: 256M', 'Constraints': {}, 'NumUnits': 2, 'ServiceName': 'mysql'}]})
Out[18]: {'Results': [{'Error': None}]}
```

Signed-off-by: Adam Stokes adam.stokes@ubuntu.com
